### PR TITLE
Add Flutter reminder app skeleton

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 This repository contains a simplified Flutter application skeleton for a persistent reminder system. The app demonstrates:
 
 - Task management with subtasks
+- Add and edit tasks with urgency levels
 - Persistent urgency settings (Normal, Urgent, Super Important)
 - Firestore integration for syncing tasks
 - Local notifications scheduled through background services

--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Reminder App
+
+This repository contains a simplified Flutter application skeleton for a persistent reminder system. The app demonstrates:
+
+- Task management with subtasks
+- Persistent urgency settings (Normal, Urgent, Super Important)
+- Firestore integration for syncing tasks
+- Local notifications scheduled through background services
+- Editable reminder frequencies in a settings screen
+
+The project is structured for future expansion with features like image or voice note attachments and desktop support.

--- a/README.txt
+++ b/README.txt
@@ -1,1 +1,0 @@
-Hello Got and GitHub

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/material.dart';
+import 'package:firebase_core/firebase_core.dart';
+import 'models/urgency_setting.dart';
+import 'services/firestore_service.dart';
+import 'services/notification_service.dart';
+import 'screens/task_list_screen.dart';
+import 'screens/settings_screen.dart';
+
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await Firebase.initializeApp();
+  final notificationService = NotificationService();
+  await notificationService.init();
+
+  runApp(ReminderApp());
+}
+
+class ReminderApp extends StatefulWidget {
+  @override
+  State<ReminderApp> createState() => _ReminderAppState();
+}
+
+class _ReminderAppState extends State<ReminderApp> {
+  final FirestoreService _service = FirestoreService();
+
+  final Map<String, UrgencySetting> _urgency = {
+    'Normal': UrgencySetting(60),
+    'Urgent': UrgencySetting(30),
+    'Super Important': UrgencySetting(5),
+  };
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'Reminder App',
+      theme: ThemeData(primarySwatch: Colors.blue),
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Tasks'),
+          actions: [
+            IconButton(
+              icon: const Icon(Icons.settings),
+              onPressed: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => SettingsScreen(
+                      settings: _urgency,
+                      onChanged: (key, minutes) {
+                        setState(() {
+                          _urgency[key] = UrgencySetting(minutes);
+                        });
+                      },
+                    ),
+                  ),
+                );
+              },
+            ),
+          ],
+        ),
+        body: TaskListScreen(service: _service),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'models/urgency_setting.dart';
+import 'models/task.dart';
 import 'services/firestore_service.dart';
 import 'services/notification_service.dart';
 import 'screens/task_list_screen.dart';
@@ -12,22 +13,87 @@ void main() async {
   final notificationService = NotificationService();
   await notificationService.init();
 
-  runApp(ReminderApp());
+  runApp(ReminderApp(notificationService: notificationService));
 }
 
 class ReminderApp extends StatefulWidget {
+  final NotificationService notificationService;
+  const ReminderApp({super.key, required this.notificationService});
   @override
   State<ReminderApp> createState() => _ReminderAppState();
 }
 
 class _ReminderAppState extends State<ReminderApp> {
   final FirestoreService _service = FirestoreService();
+  late final NotificationService _notifications;
 
-  final Map<String, UrgencySetting> _urgency = {
-    'Normal': UrgencySetting(60),
-    'Urgent': UrgencySetting(30),
-    'Super Important': UrgencySetting(5),
+  final Map<Urgency, UrgencySetting> _urgency = {
+    Urgency.normal: UrgencySetting(60),
+    Urgency.urgent: UrgencySetting(30),
+    Urgency.superImportant: UrgencySetting(5),
   };
+
+  @override
+  void initState() {
+    super.initState();
+    _notifications = widget.notificationService;
+  }
+
+  Future<void> _addTask() async {
+    final titleController = TextEditingController();
+    Urgency urgency = Urgency.normal;
+    await showDialog(
+      context: context,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setState) => AlertDialog(
+          title: const Text('New Task'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              TextField(controller: titleController),
+              DropdownButton<Urgency>(
+                value: urgency,
+                onChanged: (value) => setState(() {
+                  urgency = value ?? Urgency.normal;
+                }),
+                items: Urgency.values
+                    .map(
+                      (u) => DropdownMenuItem(
+                        value: u,
+                        child: Text(u.name),
+                      ),
+                    )
+                    .toList(),
+              ),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Cancel'),
+            ),
+            ElevatedButton(
+              onPressed: () async {
+                final id = _service.newId();
+                final task = Task(id: id, title: titleController.text, urgency: urgency);
+                await _service.saveTask(task);
+                final minutes = _urgency[urgency]?.minutes ?? 60;
+                await _notifications.scheduleRepeating(
+                  id.hashCode,
+                  task.title,
+                  'Reminder',
+                  Duration(minutes: minutes),
+                );
+                // ignore: use_build_context_synchronously
+                Navigator.pop(context);
+              },
+              child: const Text('Add'),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
 
   @override
   Widget build(BuildContext context) {
@@ -59,6 +125,10 @@ class _ReminderAppState extends State<ReminderApp> {
           ],
         ),
         body: TaskListScreen(service: _service),
+        floatingActionButton: FloatingActionButton(
+          onPressed: _addTask,
+          child: const Icon(Icons.add),
+        ),
       ),
     );
   }

--- a/lib/models/subtask.dart
+++ b/lib/models/subtask.dart
@@ -1,0 +1,20 @@
+class Subtask {
+  String title;
+  bool done;
+
+  Subtask({required this.title, this.done = false});
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'done': done,
+    };
+  }
+
+  factory Subtask.fromMap(Map<String, dynamic> map) {
+    return Subtask(
+      title: map['title'] ?? '',
+      done: map['done'] ?? false,
+    );
+  }
+}

--- a/lib/models/task.dart
+++ b/lib/models/task.dart
@@ -1,0 +1,40 @@
+import 'subtask.dart';
+
+enum Urgency { normal, urgent, superImportant }
+
+class Task {
+  String id;
+  String title;
+  Urgency urgency;
+  bool completed;
+  List<Subtask> subtasks;
+
+  Task({
+    required this.id,
+    required this.title,
+    this.urgency = Urgency.normal,
+    this.completed = false,
+    this.subtasks = const [],
+  });
+
+  Map<String, dynamic> toMap() {
+    return {
+      'title': title,
+      'urgency': urgency.index,
+      'completed': completed,
+      'subtasks': subtasks.map((s) => s.toMap()).toList(),
+    };
+  }
+
+  factory Task.fromMap(String id, Map<String, dynamic> map) {
+    return Task(
+      id: id,
+      title: map['title'] ?? '',
+      urgency: Urgency.values[map['urgency'] ?? 0],
+      completed: map['completed'] ?? false,
+      subtasks: (map['subtasks'] as List<dynamic>? ?? [])
+          .map((e) => Subtask.fromMap(e))
+          .toList(),
+    );
+  }
+}

--- a/lib/models/urgency_setting.dart
+++ b/lib/models/urgency_setting.dart
@@ -1,0 +1,4 @@
+class UrgencySetting {
+  int minutes;
+  UrgencySetting(this.minutes);
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,0 +1,49 @@
+import 'package:flutter/material.dart';
+import '../models/urgency_setting.dart';
+
+class SettingsScreen extends StatefulWidget {
+  final Map<String, UrgencySetting> settings;
+  final void Function(String, int) onChanged;
+  const SettingsScreen({super.key, required this.settings, required this.onChanged});
+
+  @override
+  State<SettingsScreen> createState() => _SettingsScreenState();
+}
+
+class _SettingsScreenState extends State<SettingsScreen> {
+  late Map<String, TextEditingController> _controllers;
+
+  @override
+  void initState() {
+    super.initState();
+    _controllers = {
+      for (var entry in widget.settings.entries)
+        entry.key: TextEditingController(text: entry.value.minutes.toString())
+    };
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Settings')),
+      body: ListView(
+        children: widget.settings.keys.map((key) {
+          return ListTile(
+            title: Text('$key minutes'),
+            trailing: SizedBox(
+              width: 80,
+              child: TextField(
+                controller: _controllers[key],
+                keyboardType: TextInputType.number,
+                onSubmitted: (value) {
+                  final minutes = int.tryParse(value) ?? widget.settings[key]!.minutes;
+                  widget.onChanged(key, minutes);
+                },
+              ),
+            ),
+          );
+        }).toList(),
+      ),
+    );
+  }
+}

--- a/lib/screens/settings_screen.dart
+++ b/lib/screens/settings_screen.dart
@@ -1,9 +1,10 @@
 import 'package:flutter/material.dart';
 import '../models/urgency_setting.dart';
+import '../models/task.dart';
 
 class SettingsScreen extends StatefulWidget {
-  final Map<String, UrgencySetting> settings;
-  final void Function(String, int) onChanged;
+  final Map<Urgency, UrgencySetting> settings;
+  final void Function(Urgency, int) onChanged;
   const SettingsScreen({super.key, required this.settings, required this.onChanged});
 
   @override
@@ -11,7 +12,7 @@ class SettingsScreen extends StatefulWidget {
 }
 
 class _SettingsScreenState extends State<SettingsScreen> {
-  late Map<String, TextEditingController> _controllers;
+  late Map<Urgency, TextEditingController> _controllers;
 
   @override
   void initState() {
@@ -29,7 +30,7 @@ class _SettingsScreenState extends State<SettingsScreen> {
       body: ListView(
         children: widget.settings.keys.map((key) {
           return ListTile(
-            title: Text('$key minutes'),
+            title: Text('${key.name} minutes'),
             trailing: SizedBox(
               width: 80,
               child: TextField(

--- a/lib/screens/task_detail_screen.dart
+++ b/lib/screens/task_detail_screen.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+import '../models/subtask.dart';
+import '../services/firestore_service.dart';
+
+class TaskDetailScreen extends StatefulWidget {
+  final Task task;
+  final FirestoreService service;
+  const TaskDetailScreen({super.key, required this.task, required this.service});
+
+  @override
+  State<TaskDetailScreen> createState() => _TaskDetailScreenState();
+}
+
+class _TaskDetailScreenState extends State<TaskDetailScreen> {
+  late Task _task;
+
+  @override
+  void initState() {
+    super.initState();
+    _task = widget.task;
+  }
+
+  void _toggleSubtask(int index, bool? value) {
+    setState(() {
+      _task.subtasks[index].done = value ?? false;
+    });
+    widget.service.saveTask(_task);
+  }
+
+  void _deleteSubtask(int index) {
+    setState(() {
+      _task.subtasks.removeAt(index);
+    });
+    widget.service.saveTask(_task);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: Text(_task.title)),
+      body: ListView.builder(
+        itemCount: _task.subtasks.length,
+        itemBuilder: (context, index) {
+          final subtask = _task.subtasks[index];
+          return Dismissible(
+            key: ValueKey(subtask.title + index.toString()),
+            onDismissed: (_) => _deleteSubtask(index),
+            child: CheckboxListTile(
+              title: Text(subtask.title),
+              value: subtask.done,
+              onChanged: (value) => _toggleSubtask(index, value),
+            ),
+          );
+        },
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () async {
+          final controller = TextEditingController();
+          await showDialog(
+            context: context,
+            builder: (context) => AlertDialog(
+              title: const Text('Add Subtask'),
+              content: TextField(controller: controller),
+              actions: [
+                TextButton(
+                  onPressed: () {
+                    Navigator.pop(context);
+                  },
+                  child: const Text('Cancel'),
+                ),
+                ElevatedButton(
+                  onPressed: () {
+                    setState(() {
+                      _task.subtasks.add(Subtask(title: controller.text));
+                    });
+                    widget.service.saveTask(_task);
+                    Navigator.pop(context);
+                  },
+                  child: const Text('Add'),
+                ),
+              ],
+            ),
+          );
+        },
+        child: const Icon(Icons.add),
+      ),
+    );
+  }
+}

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import '../models/task.dart';
 import '../services/firestore_service.dart';
+import 'task_detail_screen.dart';
 
 class TaskListScreen extends StatelessWidget {
   final FirestoreService service;
@@ -33,7 +34,14 @@ class TaskListScreen extends StatelessWidget {
                   );
                 },
               ),
-              onTap: () {},
+              onTap: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (_) => TaskDetailScreen(task: task, service: service),
+                  ),
+                );
+              },
             );
           },
         );

--- a/lib/screens/task_list_screen.dart
+++ b/lib/screens/task_list_screen.dart
@@ -1,0 +1,43 @@
+import 'package:flutter/material.dart';
+import '../models/task.dart';
+import '../services/firestore_service.dart';
+
+class TaskListScreen extends StatelessWidget {
+  final FirestoreService service;
+  const TaskListScreen({super.key, required this.service});
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<List<Task>>(
+      stream: service.tasksStream(),
+      builder: (context, snapshot) {
+        final tasks = snapshot.data ?? [];
+        return ListView.builder(
+          itemCount: tasks.length,
+          itemBuilder: (context, index) {
+            final task = tasks[index];
+            return ListTile(
+              title: Text(task.title),
+              subtitle: Text(task.urgency.name),
+              trailing: Checkbox(
+                value: task.completed,
+                onChanged: (_) {
+                  service.saveTask(
+                    Task(
+                      id: task.id,
+                      title: task.title,
+                      urgency: task.urgency,
+                      completed: !task.completed,
+                      subtasks: task.subtasks,
+                    ),
+                  );
+                },
+              ),
+              onTap: () {},
+            );
+          },
+        );
+      },
+    );
+  }
+}

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -4,6 +4,10 @@ import '../models/task.dart';
 class FirestoreService {
   final _db = FirebaseFirestore.instance;
 
+  String newId() {
+    return _db.collection('tasks').doc().id;
+  }
+
   Stream<List<Task>> tasksStream() {
     return _db.collection('tasks').snapshots().map((snapshot) {
       return snapshot.docs

--- a/lib/services/firestore_service.dart
+++ b/lib/services/firestore_service.dart
@@ -1,0 +1,22 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import '../models/task.dart';
+
+class FirestoreService {
+  final _db = FirebaseFirestore.instance;
+
+  Stream<List<Task>> tasksStream() {
+    return _db.collection('tasks').snapshots().map((snapshot) {
+      return snapshot.docs
+          .map((doc) => Task.fromMap(doc.id, doc.data()))
+          .toList();
+    });
+  }
+
+  Future<void> saveTask(Task task) {
+    return _db.collection('tasks').doc(task.id).set(task.toMap());
+  }
+
+  Future<void> deleteTask(String id) {
+    return _db.collection('tasks').doc(id).delete();
+  }
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_local_notifications/flutter_local_notifications.dart';
+import 'package:workmanager/workmanager.dart';
+
+class NotificationService {
+  final _flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
+
+  Future<void> init() async {
+    const initializationSettings = InitializationSettings(
+      android: AndroidInitializationSettings('@mipmap/ic_launcher'),
+      iOS: DarwinInitializationSettings(),
+    );
+    await _flutterLocalNotificationsPlugin.initialize(initializationSettings);
+  }
+
+  Future<void> scheduleRepeating(
+    int id,
+    String title,
+    String body,
+    Duration repeatInterval,
+  ) async {
+    await _flutterLocalNotificationsPlugin.periodicallyShow(
+      id,
+      title,
+      body,
+      RepeatInterval.everyMinute,
+      const NotificationDetails(
+        android: AndroidNotificationDetails('reminders', 'Reminders'),
+        iOS: DarwinNotificationDetails(),
+      ),
+      androidAllowWhileIdle: true,
+    );
+  }
+}
+
+void callbackDispatcher() {
+  Workmanager().executeTask((task, inputData) async {
+    // This is where background tasks would trigger notifications.
+    return Future.value(true);
+  });
+}

--- a/lib/services/notification_service.dart
+++ b/lib/services/notification_service.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_local_notifications/flutter_local_notifications.dart';
 import 'package:workmanager/workmanager.dart';
+import 'package:timezone/data/latest.dart' as tz;
+import 'package:timezone/timezone.dart' as tz;
 
 class NotificationService {
   final _flutterLocalNotificationsPlugin = FlutterLocalNotificationsPlugin();
 
   Future<void> init() async {
+    tz.initializeTimeZones();
     const initializationSettings = InitializationSettings(
       android: AndroidInitializationSettings('@mipmap/ic_launcher'),
       iOS: DarwinInitializationSettings(),
@@ -18,16 +21,19 @@ class NotificationService {
     String body,
     Duration repeatInterval,
   ) async {
-    await _flutterLocalNotificationsPlugin.periodicallyShow(
+    await _flutterLocalNotificationsPlugin.zonedSchedule(
       id,
       title,
       body,
-      RepeatInterval.everyMinute,
+      tz.TZDateTime.now(tz.local).add(repeatInterval),
       const NotificationDetails(
         android: AndroidNotificationDetails('reminders', 'Reminders'),
         iOS: DarwinNotificationDetails(),
       ),
       androidAllowWhileIdle: true,
+      uiLocalNotificationDateInterpretation:
+          UILocalNotificationDateInterpretation.absoluteTime,
+      matchDateTimeComponents: DateTimeComponents.time,
     );
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,0 +1,21 @@
+name: reminder_app
+version: 0.1.0
+environment:
+  sdk: '>=2.17.0 <3.0.0'
+
+dependencies:
+  flutter:
+    sdk: flutter
+  firebase_core: ^2.24.0
+  cloud_firestore: ^4.9.1
+  flutter_local_notifications: ^15.1.0
+  workmanager: ^0.5.1
+  hive: ^2.2.3
+
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+  flutter_lints: ^2.0.0
+
+flutter:
+  uses-material-design: true

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,7 @@ dependencies:
   flutter_local_notifications: ^15.1.0
   workmanager: ^0.5.1
   hive: ^2.2.3
+  timezone: ^0.9.2
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add Flutter project skeleton with Firebase, notifications, background tasks
- implement task, subtask, and urgency models
- add basic UI screens for tasks, details, and settings
- include Firestore and notification services
- document the project in README

## Testing
- `flutter pub get` *(fails: flutter not installed)*

------
https://chatgpt.com/codex/tasks/task_e_684187613f04832aa1a4ab19ec992577